### PR TITLE
Reorder GCC linked libraries parameters last

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -39,12 +39,12 @@ all : $(TARGETS)
 fwupdate : libfwup.so
 
 % : %.o
-	$(CC) $(BUILDFLAGS) $(BIN_CCLDFLAGS) -o $@ $(patsubst lib%.so,-l%,$^)
+	$(CC) $(BUILDFLAGS) -o $@ $(patsubst lib%.so,-l%,$^) $(BIN_CCLDFLAGS)
 
 %.so.$(VERSION) : %.o
-	$(CC) $(BUILDFLAGS) $(LIB_CCLDFLAGS) \
+	$(CC) $(BUILDFLAGS) \
 		-Wl,-soname,$(patsubst %.o,%.so.$(MAJOR_VERSION),$<) \
-		-o $@ $^
+		-o $@ $^ $(LIB_CCLDFLAGS)
 
 %.so.$(MAJOR_VERSION) : %.so.$(VERSION)
 	ln -sf $< $@


### PR DESCRIPTION
When linking with --as-needed, which is default on some distributions, the
linking will fail if libraries are listed before the objects that reference
them.

See: https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition
See: https://wiki.debian.org/ToolChain/DSOLinking#Only_link_with_needed_libraries
Signed-off-by: Mathieu Trudel-Lapierre mathieu.trudel-lapierre@canonical.com
