### PR TITLE
Fix using host gcc to locate libgcc.

### DIFF
--- a/efi/Makefile
+++ b/efi/Makefile
@@ -72,7 +72,7 @@ endif
 
 %.so : %.o
 	$(LD) $(LDFLAGS) -o $@ $^ -lefi -lgnuefi \
-		$(shell gcc -print-libgcc-file-name) \
+		$(shell $(CC) -print-libgcc-file-name) \
 		-T elf_$(ARCH)_efi.lds
 
 %.o : %.c


### PR DESCRIPTION
Signed-off-by: Lans Zhang jia.zhang@windriver.com
