### PR TITLE
Clear time_attempted for the existing status info

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -990,6 +990,7 @@ fwup_set_up_update(fwup_resource *re, uint64_t hw_inst, int infd)
 
 	/* save this to the hardware */
 	info->status = FWUPDATE_ATTEMPT_UPDATE;
+	memset(&info->time_attempted, 0, sizeof(info->time_attempted));
 	rc = put_info(info);
 	if (rc < 0) {
 		warn("put_info failed.\n");
@@ -1076,6 +1077,7 @@ fwup_set_up_update_with_buf(fwup_resource *re, uint64_t hw_inst, const void *buf
 
 	/* save this to the hardware */
 	info->status = FWUPDATE_ATTEMPT_UPDATE;
+	memset(&info->time_attempted, 0, sizeof(info->time_attempted));
 	rc = put_info(info);
 	if (rc < 0) {
 		warn("put_info failed.\n");


### PR DESCRIPTION
If the info inherits an existing status info, the time_attempted
reflects the last update timestamp. In this case, the time_attempted
should be clear before re-submittion.

Signed-off-by: Lans Zhang jia.zhang@windriver.com
