### PR TITLE
Fix getting the value of SHIM_DEBUG

### DIFF
--- a/efi/fwupdate.c
+++ b/efi/fwupdate.c
@@ -573,7 +573,7 @@ debug_hook(void)
 	 * who and where we are, and also enable our debugging output.
 	 */
 	efi_status = uefi_call_wrapper(RT->GetVariable, 5, L"SHIM_DEBUG",
-				       &guid, &attributes,  &data, &data_size);
+				       &guid, &attributes,  &data_size, &data);
 	if (EFI_ERROR(efi_status) || data != 1) {
 		return;
 	}


### PR DESCRIPTION
The data and data_size parameters are reversed due to being drunk.

Signed-off-by: Lans Zhang jia.zhang@windriver.com
