### PR TITLE
Fix firmware update failure due to not finding capsule image

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -787,7 +787,7 @@ fwup_get_existing_media_path (update_info *info)
 	untilt_slashes(relpath);
 
 	/* build a complete path */
-	rc = asprintf(&fullpath, "/boot/efi/%s", relpath);
+	rc = asprintf(&fullpath, "/boot/efi%s", relpath);
 	if (rc < 0)
 		goto out;
 


### PR DESCRIPTION
Repeating executing fwupdate or running it based on an existing status
variable will eventually generate a status variable with multiple "\"
prefixes in the file path, causing fwupdate.efi cannot find the capsule
image.

The root cause is the constructed fullpath always has a duplicated "\"
during the build. Actually we can trust the fact that the relpath obtained
from existing status variable is always an absolute path.

Signed-off-by: Lans Zhang jia.zhang@windriver.com
