### PR TITLE
Switch to abbreviated paths by default for fwupdate control variables.

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -865,7 +865,8 @@ set_efidp_header (update_info *info, const char *path)
 
 	/* get the size of the path first */
 	req = efi_generate_file_device_path(NULL, 0, path,
-				EFIBOOT_OPTIONS_IGNORE_FS_ERROR);
+				EFIBOOT_OPTIONS_IGNORE_FS_ERROR |
+				EFIBOOT_ABBREV_HD);
 	if (req < 0) {
 		rc = -1;
 		goto out;
@@ -885,7 +886,8 @@ set_efidp_header (update_info *info, const char *path)
 	/* actually get the path this time */
 	efidp_header *dp = (efidp_header *)dp_buf;
 	sz = efi_generate_file_device_path(dp_buf, req, path,
-				EFIBOOT_OPTIONS_IGNORE_FS_ERROR);
+				EFIBOOT_OPTIONS_IGNORE_FS_ERROR |
+				EFIBOOT_ABBREV_HD);
 	if (sz < 0) {
 		rc = -1;
 		goto out;


### PR DESCRIPTION
Since the fixes from https://github.com/rhinstaller/fwupdate/pull/24 were
included, it makes more sense to search the system for the matching partition.

This avoids any issues that happen with mismatched SATA PMP nodes.
