### PR TITLE
Cleanup EFI NVRAM Boot#### entries as well on install

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -76,6 +76,7 @@ test : tester
 clean :
 	@rm -vf $(BINTARGETS) $(LIBTARGETS) $(PCTARGETS) $(POTARGETS) *.o
 	@rm -vf libfwup.so*
+	@rm -vf cleanup.service cleanup
 
 install : all
 	$(INSTALL) -d -m 755 $(DESTDIR)/$(libdir)

--- a/linux/cleanup.in
+++ b/linux/cleanup.in
@@ -4,6 +4,14 @@ if [ -e "@@DATADIR@@fwupdate/done" ]; then
 	exit 0
 fi
 
+BOOTNUM=$(efibootmgr | grep "Linux Firmware Updater" | sed "s/\ .*//; s/*//; s/Boot//")
+if [ -n "$BOOTNUM" ]; then
+	for num in $BOOTNUM; do
+		efibootmgr -q -b $num -B
+	done
+fi
+
+
 for x in /boot/efi/EFI/@@EFIDIR@@/fw/fwupdate-* ; do
 	if [ "${x}" != "/boot/efi/EFI/@@EFIDIR@@/fw/fwupdate-*" ]; then
 		rm -f "${x}"


### PR DESCRIPTION
It's possible that a previous install created a Boot#### entry for
Linux Firmware Updater

If so, this will be pointing to a $(FWUP).efi on an ESP with a potentially
different GUID embedded in the DP.

To avoid an undefined collision, remove that old entry on install if it exists.
