### PR TITLE
fwupdate: support showing the info of fwupdate status variable

### DIFF
--- a/docs/fwupdate.1
+++ b/docs/fwupdate.1
@@ -15,6 +15,9 @@ List supported firmware updates
 \fB\-s\fR, \fB\-\-supported\fR
 Query for firmware update support
 .TP
+\fB\-i\fR, \fB\-\-info\fR
+Show the information of firmware update status
+.TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Work quietly
 .SS "Help options:"

--- a/docs/libfwup.3
+++ b/docs/libfwup.3
@@ -82,6 +82,9 @@ updated to.
 .ta \nZu
 	uint32_t *\fIstatus\fB, time_t *\fIwhen\fB);\fR\p
 Get the status for the last attempt to update firmware resource \fIre\fR.
+
+\fBvoid \fRfwup_print_update_info\fB(void);\fR\p
+Print the information of firmware update status.
 .SH AUTHORS
 .nf
 Peter Jones <pjones@redhat.com>

--- a/linux/fwupdate.c
+++ b/linux/fwupdate.c
@@ -27,7 +27,7 @@
 #define CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE   0x00020000
 #define CAPSULE_FLAGS_INITIATE_RESET          0x00040000
 
-int
+static int
 print_system_resources(void)
 {
 	fwup_resource_iter *iter;
@@ -69,6 +69,7 @@ print_system_resources(void)
 #define ACTION_APPLY		0x01
 #define ACTION_LIST		0x02
 #define ACTION_SUPPORTED	0x04
+#define ACTION_INFO		0x08
 
 int
 main(int argc, char *argv[]) {
@@ -95,6 +96,10 @@ main(int argc, char *argv[]) {
 		{"supported", 's', POPT_ARG_VAL|POPT_ARGFLAG_OR, &action,
 			ACTION_SUPPORTED,
 			_("Query for firmware update support"), NULL},
+		{"info", 'i', POPT_ARG_VAL|POPT_ARGFLAG_OR, &action,
+			ACTION_INFO,
+			_("Show the information of firmware update status"),
+			NULL},
 		{"quiet", 'q', POPT_ARG_VAL, &quiet, 1, _("Work quietly"),
 			NULL},
 		POPT_AUTOALIAS
@@ -134,7 +139,6 @@ main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
 
 	if (rc < -1)
 		errx(2, _("invalid argument: \"%s\": %s"),
@@ -197,6 +201,11 @@ main(int argc, char *argv[]) {
 			}
 		}
 		errx(2, _("firmware resource not found"));
+	} else if (action & ACTION_INFO) {
+		rc = fwup_print_update_info();
+		if (rc < 0)
+			errx(6, _("Could not display firmware update status"));
+		return 0;
 	}
 
 	return 0;

--- a/linux/include/fwup.h
+++ b/linux/include/fwup.h
@@ -53,5 +53,6 @@ extern int fwup_get_lowest_supported_fw_version(fwup_resource *re,
 extern int fwup_get_last_attempt_info(fwup_resource *re, uint32_t *version,
 			   uint32_t *status, time_t *when);
 extern const char *fwup_last_attempt_status_to_string (uint64_t status);
+extern int fwup_print_update_info(void);
 
 #endif /* LIBFW_H */


### PR DESCRIPTION
Implement --info/-i argument to support showing the contents of each
fwupdate status variable.

Signed-off-by: Lans Zhang jia.zhang@windriver.com
