### PR TITLE
Place .gnu.hash on the top of all other output sections

### DIFF
--- a/efi/elf_ia32_efi.lds
+++ b/efi/elf_ia32_efi.lds
@@ -6,6 +6,7 @@ SECTIONS
   . = 0;
   ImageBase = .;
   .hash : { *(.hash) }	/* this MUST come first! */
+  .gnu.hash : { *(.gnu.hash) }
   . = ALIGN(4096);
   .text :
   {

--- a/efi/elf_x86_64_efi.lds
+++ b/efi/elf_x86_64_efi.lds
@@ -7,6 +7,7 @@ SECTIONS
   . = 0;
   ImageBase = .;
   .hash : { *(.hash) }	/* this MUST come first! */
+  .gnu.hash : { *(.gnu.hash) }
   . = ALIGN(4096);
   .eh_frame : 
   { 


### PR DESCRIPTION
--hash-style=gnu will break the recognition of PE format by UEFI boot
manager. We now do the same way just as how to handle .hash section.

Signed-off-by: Lans Zhang jia.zhang@windriver.com
