### PR TITLE
Add support to enable firmware updates on supported systems using libsmbios

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -2,7 +2,7 @@ TOPDIR	?= $(shell pwd)/..
 include $(TOPDIR)/Make.version
 include $(TOPDIR)/Make.defaults
 
-LIB_LIBS= pthread
+LIB_LIBS= pthread smbios_c
 BIN_LIBS= popt pthread
 PKLIBS	= efivar efiboot
 CFLAGS	?= -g -O0

--- a/linux/include/fwup.h
+++ b/linux/include/fwup.h
@@ -17,6 +17,7 @@
 #include <time.h>
 
 extern int fwup_supported(void);
+extern int enable_esrt(void);
 
 #define FWUP_RESOURCE_TYPE_UNKNOWN		0
 #define FWUP_RESOURCE_TYPE_SYSTEM_FIRMWARE	1


### PR DESCRIPTION
Systems running a Dell BIOS have the ability to turn on and off the feature for enabling capsule updates.  When turned off, the ESRT table is no longer present.

It's possible to identify this situation, notify the user and change the setting from within the OS.  This would require a reboot for the BIOS and kernel to populate the ESRT table.
