### PR TITLE
Add a flag to Allow flashing GUID's that don't match the ESRT table

### DIFF
--- a/linux/include/fwup.h
+++ b/linux/include/fwup.h
@@ -49,6 +49,7 @@ extern int fwup_resource_iter_destroy(fwup_resource_iter **iter);
 extern int fwup_set_up_update(fwup_resource *re, uint64_t hw_inst, int infd);
 extern int fwup_set_up_update_with_buf(fwup_resource *re, uint64_t hw_inst,
 				       const void *buf, size_t sz);
+extern int fwup_set_guid(fwup_resource_iter *iter, fwup_resource **re, const efi_guid_t *guid);
 extern int fwup_clear_status(fwup_resource *re);
 extern int fwup_get_guid(fwup_resource *re, efi_guid_t **guid);
 extern int fwup_get_fw_type(fwup_resource *re, uint32_t *type);

--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -469,6 +469,19 @@ fwup_resource_iter_next(fwup_resource_iter *iter, fwup_resource **re)
 }
 
 int
+fwup_set_guid(fwup_resource_iter *iter, fwup_resource **re, const efi_guid_t *guid) {
+	fwup_resource *res;
+	if (!iter || !re) {
+		errno = EINVAL;
+		return -1;
+	}
+	res = &iter->re;
+	res->esre.guid = *guid;
+	*re = res;
+	return 1;
+}
+
+int
 fwup_clear_status(fwup_resource *re)
 {
 	if (!re) {


### PR DESCRIPTION
Some vendors have payloads for devices on the system that can be updated via capsules but for various reasons won't be populated in the ESRT.

This allows fwupdate to be able to attempt to flash those payloads by the user providing a force flag.
