### PR TITLE
Prepend "space" to the load option

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -665,6 +665,7 @@ set_up_boot_next(void)
 	char *shim_fs_path = NULL;
 	char *fwup_fs_path = NULL;
 	char *fwup_esp_path = NULL;
+	char *fwup_option = NULL;
 	int use_fwup_path = 0;
 
 	char *label = NULL;
@@ -690,7 +691,10 @@ set_up_boot_next(void)
 		goto out;
 
 	if (!use_fwup_path) {
-		loader_str = utf8_to_ucs2((uint8_t *)fwup_esp_path, -1);
+		fwup_option = alloca(strlen(fwup_esp_path) + 2);
+		fwup_option[0] = ' ';
+		strcpy(fwup_option + 1, fwup_esp_path);
+		loader_str = utf8_to_ucs2((uint8_t *)fwup_option, -1);
 		loader_sz = ucs2len(loader_str, -1) * 2;
 		if (loader_sz)
 			loader_sz += 2;


### PR DESCRIPTION
When using shim as the first stage loader, merely the path to fwup_.efi
is not enough since shim will ignore the string before the first ' '.
This commit prepends ' ' to the path to make shim load fwup_.efi.

Signed-off-by: Gary Lin glin@suse.com
