### PR TITLE
Fix uninitialized variable.

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -777,7 +777,7 @@ add_to_boot_order(uint16_t boot_entry)
 	size_t boot_order_size = 0;
 	uint32_t attr;
 	int rc;
-	unsigned int i;
+	unsigned int i = 0;
 
 	rc = efi_get_variable_size(efi_guid_global, "BootOrder",
 				   &boot_order_size);


### PR DESCRIPTION
If boot_order_size is 0, i was never set. On gcc-6.3.1, this broke the
build if compiled with -O2 (-Werror=maybe_uninitialized). This is the
error:

libfwup.c: In function 'set_up_boot_next':
libfwup.c:818:16: error: 'i' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  new_boot_order[i] = boot_entry;
                ^
libfwup.c:780:15: note: 'i' was declared here
  unsigned int i;
               ^
cc1: all warnings being treated as errors