### PR TITLE
Fix regression in "objcopy version check" (AKA `expr: syntax error`)

### DIFF
--- a/efi/Makefile
+++ b/efi/Makefile
@@ -15,7 +15,15 @@ CCLDFLAGS	?= -nostdlib -Wl,--warn-common \
 	-Wl,-shared -Wl,-Bsymbolic -L$(LIBDIR) -L$(GNUEFIDIR) \
 	-Wl,--build-id=sha1 -Wl,--hash-style=sysv \
 	$(GNUEFIDIR)/crt0-efi-$(ARCH).o
-OBJCOPY_GTE224 = $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^[^0-9]*//g' | cut -f1-2 -d.` \>= 2.24)
+
+define objcopy_version =
+  $(OBJCOPY) --version |
+    sed -e '/^GNU objcopy/! d;
+	    : loop1; s/([^)(]*)//g;   t loop1;
+	    : loop2; s/\[[^][]*\]//g; t loop2;
+	    s/.* \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/;'
+endef
+OBJCOPY_GTE224 := $(shell expr `$(objcopy_version)` \>= 2.24)
 
 FWUP = fwupdate
 

--- a/linux/fwupdate.c
+++ b/linux/fwupdate.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[]) {
 
 	efi_guid_t guid;
 
-	setlocale(LC_ALL, "");
+	setlocale(LC_ALL, EMPTY);
 	bindtextdomain("fwupdate", LOCALEDIR);
 	textdomain("fwupdate");
 

--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -48,7 +48,7 @@ static char *arch_names_32[] = {
 #if defined(__x86_64__) || defined(__i386__) || defined(__i686__)
 	"ia32",
 #endif
-	""
+	EMPTY
 	};
 
 static int n_arches_32 = sizeof(arch_names_32) / sizeof(arch_names_32[0]);
@@ -59,7 +59,7 @@ static char *arch_names_64[] = {
 #elif defined(__aarch64__)
 	"aa64",
 #endif
-	""
+	EMPTY
 	};
 
 static int n_arches_64 = sizeof(arch_names_64) / sizeof(arch_names_64[0]);

--- a/linux/util.h
+++ b/linux/util.h
@@ -22,6 +22,7 @@
 #define N_(String) (String)
 #define C_(Context,String) dgettext (Context,String)
 #define NC_(Context, String) (String)
+#define EMPTY ""
 
 extern int quiet;
 


### PR DESCRIPTION
While commit 8418fee4 may have fixed the check for "some distributions",
it broke the same check for others, like

`GNU objcopy (WinAVR 20090313) 2.19`
`GNU objcopy (AVR_8_bit_GNU_Toolchain_3.4.3_1072) 2.23.2`
`GNU objcopy (Codescape GNU Tools 2016.05-03 for MIPS MTI Bare Metal) 2.24.90`
`GNU objcopy (GNU Binutils; openSUSE Leap 42.2) 2.26.1`
`GNU objcopy (GNU Binutils; SUSE Linux Enterprise 12) 2.26.1`

(some more, some less relevant... ;)

This version is meant to cover them all (or at least be easily extensible
to do so, as demonstrated with square brackets).

Signed-off-by: Raymund Will <rw@suse.com>