### PR TITLE
Allow to specify the pkg-config command

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -2,6 +2,7 @@ NAME		= fwupdate
 COMMIT_ID	= $(shell git log -1 --pretty=%H 2>/dev/null || echo master)
 INSTALL 	?= install
 MAKE		?= make
+PKG_CONFIG	?= $(CROSS_COMPILE)pkg-config
 CC		= $(CROSS_COMPILE)gcc
 LD		= $(CROSS_COMPILE)ld
 OBJCOPY		= $(CROSS_COMPILE)objcopy

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -13,14 +13,14 @@ CFLAGS	?= -g3 -Og -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 \
 PJONES	=
 BIN_CCLDFLAGS = $(foreach lib,$(BIN_LIBS),-l$(lib)) \
 	$(foreach pklib,$(PKLIBS), \
-		$(shell pkg-config --libs-only-l --libs-only-other $(pklib))) \
+		$(shell $(PKG_CONFIG) --libs-only-l --libs-only-other $(pklib))) \
 	$(LDFLAGS) -pie -fPIE -Wl,-z,relro,-z,now -L.
 LIB_CCLDFLAGS = $(foreach lib,$(LIB_LIBS),-l$(lib)) \
 	$(foreach pklib,$(PKLIBS), \
-		$(shell pkg-config --libs-only-l --libs-only-other $(pklib))) \
+		$(shell $(PKG_CONFIG) --libs-only-l --libs-only-other $(pklib))) \
 	$(LDFLAGS) -shared -fPIC -Wl,-z,relro,-z,now
 
-HAVE_LIBSMBIOS := $(shell pkg-config --exists libsmbios_c && \
+HAVE_LIBSMBIOS := $(shell $(PKG_CONFIG) --exists libsmbios_c && \
 				echo yes || echo no)
 ifeq ($(HAVE_LIBSMBIOS),yes)
 	PKLIBS += libsmbios_c
@@ -33,7 +33,7 @@ BUILDFLAGS := $(CFLAGS) -Wall -Wextra -Werror -Wno-error=cpp \
 	-DLOCALEDIR=\"$(localedir)\" -D_GNU_SOURCE \
 	-DFWUP_EFI_DIR_NAME=\"$(EFIDIR)\"  \
 	-I$(TOPDIR)/linux/include -iquote$(TOPDIR)/include/ \
-	$(foreach pklib,$(PKLIBS), $(shell pkg-config --cflags $(pklib))) \
+	$(foreach pklib,$(PKLIBS), $(shell $(PKG_CONFIG) --cflags $(pklib))) \
 	$(PJONES)
 
 BINTARGETS=fwupdate


### PR DESCRIPTION
This commit fixes a build issue on cross environments where the pkg-config
command may be prefixed with e.g. the host triplet, like
x86_64-pc-linux-gnu-pkg-config and results in a build failure not finding
the pkg-config command.