### PR TITLE
Make EFI location configurable

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -42,9 +42,14 @@ EFIDIR		?= $(shell x=$$(which --skip-alias --skip-functions git 2>/dev/null) ; [
 ifeq ($(EFIDIR),)
 	EFIDIR_ERROR = $(error EFIDIR or .gitconfig fwupdate.efidir must be set to this distro's reserved EFI System Partition subdirectory name)
 endif
+EFIBASE		?= $(shell x=$$(which --skip-alias --skip-functions git 2>/dev/null) ; [ -n "$$x" ] && git config --get fwupdate.efibase)
+ifeq ($(EFIBASE),)
+	EFIBASE = "/boot/efi/EFI"
+endif
+
 DEBUGINFO	?= $(prefix)lib/debug
 DEBUGSOURCE	?= $(prefix)src/debug
-TARGETDIR	?= /boot/efi/EFI/$(EFIDIR)
+TARGETDIR	?= $(EFIBASE)/$(EFIDIR)
 
 .PHONY: check_efidir_error
 check_efidir_error : ; $(EFIDIR_ERROR) $(info Building with EFIDIR as $(EFIDIR))

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -32,6 +32,7 @@ BUILDFLAGS := $(CFLAGS) -Wall -Wextra -Werror -Wno-error=cpp \
 	-fshort-wchar --std=gnu11 \
 	-DLOCALEDIR=\"$(localedir)\" -D_GNU_SOURCE \
 	-DFWUP_EFI_DIR_NAME=\"$(EFIDIR)\"  \
+	-DFWUP_EFI_BASE_DIR_NAME=\"$(EFIBASE)\"  \
 	-I$(TOPDIR)/linux/include -iquote$(TOPDIR)/include/ \
 	$(foreach pklib,$(PKLIBS), $(shell pkg-config --cflags $(pklib))) \
 	$(PJONES)
@@ -77,6 +78,7 @@ include/fwup.h : | include/fwup-version.h
 		-e "s,@@FWUP_MAJOR_VERSION@@,$(MAJOR_VERSION),g" \
 		-e "s,@@FWUP_MINOR_VERSION@@,$(MINOR_VERSION),g" \
 		-e "s,@@DATADIR@@,$(datadir),g" \
+		-e "s,@@EFIBASE@@,$(EFIBASE),g" \
 		-e "s,@@EFIDIR@@,$(EFIDIR),g" \
 		-e "s,@@LIBDIR@@,$(libdir),g" \
 		-e "s,@@LIBEXECDIR@@,$(libexecdir),g" \

--- a/linux/cleanup.in
+++ b/linux/cleanup.in
@@ -14,8 +14,8 @@ if [ -n "$BOOTNUM" ]; then
 fi
 
 
-for x in /boot/efi/EFI/@@EFIDIR@@/fw/fwupdate-* ; do
-	if [ "${x}" != "/boot/efi/EFI/@@EFIDIR@@/fw/fwupdate-*" ]; then
+for x in @@EFIBASE@@/@@EFIDIR@@/fw/fwupdate-* ; do
+	if [ "${x}" != "@@EFIBASE@@/@@EFIDIR@@/fw/fwupdate-*" ]; then
 		rm -f "${x}"
 	fi
 done

--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -710,8 +710,8 @@ get_paths(char **shim_fs_path, char **fwup_fs_path, char **fwup_esp_path)
 {
 	int ret = -1;
 
-	char shim_fs_path_tmpl[] = "/boot/efi/EFI/"FWUP_EFI_DIR_NAME"/shim";
-	char fwup_fs_path_tmpl[] = "/boot/efi/EFI/"FWUP_EFI_DIR_NAME"/fwup";
+	char shim_fs_path_tmpl[] = FWUP_EFI_BASE_DIR_NAME"/"FWUP_EFI_DIR_NAME"/shim";
+	char fwup_fs_path_tmpl[] = FWUP_EFI_BASE_DIR_NAME"/"FWUP_EFI_DIR_NAME"/fwup";
 	uint8_t fwup_esp_path_tmpl[] = "\\fwup";
 
 	char *shim_fs_path_tmp = NULL;
@@ -1153,7 +1153,7 @@ get_existing_media_path(update_info *info)
 	untilt_slashes(relpath);
 
 	/* build a complete path */
-	rc = asprintf(&fullpath, "/boot/efi%s", relpath);
+	rc = asprintf(&fullpath, FWUP_EFI_BASE_DIR_NAME "%s", relpath);
 	if (rc < 0)
 		fullpath = NULL;
 
@@ -1191,7 +1191,8 @@ get_fd_and_media_path(update_info *info, char **path)
 	} else {
 		/* fall back to creating a new file from scratch */
 		rc = asprintf(&fullpath,
-			      "/boot/efi/EFI/%s/fw/fwupdate-XXXXXX.cap",
+			      "%s/%s/fw/fwupdate-XXXXXX.cap",
+			      FWUP_EFI_BASE_DIR_NAME,
 			      FWUP_EFI_DIR_NAME);
 		if (rc < 0) {
 			efi_error("asprintf failed");


### PR DESCRIPTION
Hopefully fixes https://github.com/rhboot/fwupdate/issues/58.

I installed the firmware update I needed with a version with hard coded `/boot/EFI` instead of `/boot/efi/EFI`, and ported those changes to this configurable version. I'm not terribly familiar with fwupdate, so I'm not quite sure how to test that this configurable version works too.