### PR TITLE
libfwup: Add support to do Dell UEFI capsule enable over WMI

### DIFF
--- a/linux/include/dell-wmi-smi.h
+++ b/linux/include/dell-wmi-smi.h
@@ -1,0 +1,52 @@
+/*
+ * dell-wmi-smi - kernel interface to SMI over WMI
+ *
+ * Copyright 2017 Dell, Inc.
+ *
+ * See "COPYING" for license terms.
+ *
+ * Author: Mario Limonciello <mario.limonciello@dell.com>
+ */
+
+#ifndef _DELL_WMI_SMI_H_
+#define _DELL_WMI_SMI_H_
+
+#include <sys/ioctl.h>
+
+#define DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED 0x0461
+#define DELL_CAPSULE_FIRMWARE_UPDATES_DISABLED 0x0462
+
+#define DELL_CLASS_READ_TOKEN 0
+#define DELL_SELECT_READ_TOKEN 0
+#define DELL_CLASS_WRITE_TOKEN 1
+#define DELL_SELECT_WRITE_TOKEN 0
+
+#define DELL_CLASS_ADMIN_PROP 10
+#define DELL_SELECT_ADMIN_PROP 3
+#define DELL_ADMIN_MASK 0xF
+#define DELL_ADMIN_INSTALLED 0
+
+struct calling_interface_buffer {
+	uint16_t class;
+	uint16_t select;
+	volatile uint32_t input[4];
+	volatile uint32_t output[4];
+};
+
+struct wmi_calling_interface_buffer {
+	struct calling_interface_buffer smi;
+	uint32_t argattrib;
+	uint32_t blength;
+	uint8_t data[32724];
+};
+
+#define DELL_WMI_CHAR "/dev/wmi/dell-smbios"
+#define TOKENS_SYSFS "/sys/bus/wmi/devices/A80593CE-A997-11DA-B012-B622A1EF5492/tokens"
+
+#define DELL_WMI_SMBIOS_IOC			'D'
+/* run SMBIOS calling interface command
+ * note - 32k is too big for size, so this can not be encoded in macro properly
+ */
+#define DELL_WMI_SMBIOS_CALL_CMD  	_IOWR(DELL_WMI_SMBIOS_IOC, 0, uint8_t)
+
+#endif

--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -33,16 +33,10 @@
 static int verbose;
 #include "error.h"
 
+#include <dell-wmi-smi.h>
 #ifdef FWUPDATE_HAVE_LIBSMBIOS__
 #include </usr/include/smbios_c/token.h>
 #include <smbios_c/smi.h>
-
-#define DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED 0x0461
-#define DELL_CAPSULE_FIRMWARE_UPDATES_DISABLED 0x0462
-#define DELL_CLASS_ADMIN_PROP 10
-#define DELL_SELECT_ADMIN_PROP 3
-#define DELL_ADMIN_MASK 0xF
-#define DELL_ADMIN_INSTALLED 0
 #endif
 
 static char *arch_names_32[] = {
@@ -108,6 +102,176 @@ efidp_end_entire(efidp_header *dp)
 	return 1;
 }
 
+static int
+wmi_supported()
+{
+	if (access(DELL_WMI_CHAR, F_OK) != -1)
+		return 1;
+	return 0;
+}
+
+static int
+wmi_call_ioctl(struct wmi_calling_interface_buffer *buffer)
+{
+	int fd, ret;
+	fd = open (DELL_WMI_CHAR, O_NONBLOCK);
+	ret = ioctl (fd, DELL_WMI_SMBIOS_CALL_CMD, buffer);
+	close(fd);
+	return ret;
+}
+
+static int
+wmi_find_token(uint32_t token, uint32_t *location, uint32_t *cmpvalue)
+{
+	FILE *f;
+	char buf[4096];
+	char *cur;
+	char *rest;
+	char *resti;
+	uint32_t cmptoken;
+
+	f = fopen(TOKENS_SYSFS, "rb");
+	if (!f)
+		return -2;
+	fread(buf, 1, 4096, f);
+	fclose(f);
+	rest = buf;
+	while ((cur = strtok_r(rest,"\n", &rest))) {
+		resti = cur;
+		cur = strtok_r(resti, "\t", &resti);
+		if (!cur)
+			break;
+		cmptoken = strtol(cur, NULL, 16);
+		if (cmptoken != token)
+			continue;
+		cur = strtok_r(resti, "\t", &resti);
+		*location = strtol(cur, NULL, 16);
+		cur = strtok_r(resti, "\t", &resti);
+		*cmpvalue = strtol(cur, NULL, 16);
+		return 1;
+	}
+	return -2;
+}
+
+static int
+wmi_token_is_active(uint32_t *location, uint32_t *cmpvalue)
+{
+	struct wmi_calling_interface_buffer *buffer;
+	int ret;
+	buffer = calloc(1, sizeof(struct wmi_calling_interface_buffer));
+	if (!buffer)
+		return -ENOMEM;
+	buffer->smi.class = DELL_CLASS_READ_TOKEN;
+	buffer->smi.select = DELL_SELECT_READ_TOKEN;
+	buffer->smi.input[0] = *location;
+	ret = wmi_call_ioctl(buffer);
+	if (ret != 0|| buffer->smi.output[0] != 0)
+		return ret;
+	ret = (buffer->smi.output[1] == *cmpvalue);
+	free(buffer);
+	return ret;
+}
+
+static int
+query_token(uint32_t token)
+{
+	if (wmi_supported())
+	{
+		uint32_t location;
+		uint32_t cmpvalue;
+		/* locate token */
+		if(!wmi_find_token(token, &location, &cmpvalue))
+			return -1;
+		/* query actual token status */
+		if (wmi_token_is_active(&location, &cmpvalue))
+			return 1;
+		return -1;
+	}
+#ifdef FWUPDATE_HAVE_LIBSMBIOS__
+	if (!token_is_bool(token))
+		return -1;
+	if (token_is_active(token))
+		return 1;
+	return -1;
+#endif
+	return -1;
+}
+
+static int
+activate_token(uint32_t token)
+{
+	int ret;
+	if (wmi_supported()) {
+		struct wmi_calling_interface_buffer *buffer;
+		uint32_t location;
+		uint32_t cmpvalue;
+
+		/* locate token */
+		if(!wmi_find_token(token, &location, &cmpvalue))
+			return -1;
+
+		buffer = calloc(1, sizeof(struct wmi_calling_interface_buffer));
+		if (!buffer)
+			return -ENOMEM;
+		buffer->smi.class = DELL_CLASS_WRITE_TOKEN;
+		buffer->smi.select = DELL_CLASS_READ_TOKEN;
+		buffer->smi.input[0] = location;
+		buffer->smi.input[1] = 1;
+		ret = wmi_call_ioctl(buffer);
+		free(buffer);
+		return ret;
+	}
+
+#ifdef FWUPDATE_HAVE_LIBSMBIOS__
+	token_activate(token);
+	ret = token_is_active(token);
+	if (!ret) {
+		efi_error("%d activation failed", token);
+		return -3;
+	}
+	return 2;
+#else
+	return -1;
+#endif
+}
+
+static int admin_password_present()
+{
+	int ret;
+	if (wmi_supported()) {
+		struct wmi_calling_interface_buffer *buffer;
+		buffer = calloc(1, sizeof(struct wmi_calling_interface_buffer));
+		if (!buffer)
+			return -ENOMEM;
+		buffer->smi.class = DELL_CLASS_ADMIN_PROP;
+		buffer->smi.select = DELL_SELECT_ADMIN_PROP;
+		ret = wmi_call_ioctl(buffer);
+		if (buffer->smi.output[0] != 0 ||
+		   (buffer->smi.output[1] & DELL_ADMIN_MASK) == DELL_ADMIN_INSTALLED) {
+			ret = -3;
+			goto wmi_token_cleanup;
+		}
+		ret = 2;
+wmi_token_cleanup:
+		free(buffer);
+		return ret;
+	}
+#ifdef FWUPDATE_HAVE_LIBSMBIOS__
+	uint32_t args[4] = {0,}, out[4] = {0,};
+	if (dell_simple_ci_smi(DELL_CLASS_ADMIN_PROP,
+			       DELL_SELECT_ADMIN_PROP,
+			       args, out))
+		return -2;
+	if (out[0] != 0 || (out[1] & DELL_ADMIN_MASK) == DELL_ADMIN_INSTALLED)
+		return -3;
+	return 2;
+
+#else
+	return -1;
+#endif
+
+}
+
 /*
 	fwup_esrt_disabled
 	tests if ESRT is disabled (but can be enabled)
@@ -122,26 +286,17 @@ efidp_end_entire(efidp_header *dp)
 int
 fwup_esrt_disabled(void)
 {
-#ifdef FWUPDATE_HAVE_LIBSMBIOS__
-	uint32_t args[4] = {0,}, out[4] = {0,};
-	if (!token_is_bool(DELL_CAPSULE_FIRMWARE_UPDATES_DISABLED))
-		return -1;
-	if (!token_is_active(DELL_CAPSULE_FIRMWARE_UPDATES_DISABLED))
+	int ret;
+
+	ret = query_token(DELL_CAPSULE_FIRMWARE_UPDATES_DISABLED);
+	if (ret < 0)
 	{
-		if (token_is_active(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED))
+		ret = query_token(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
+		if (ret > 0)
 			return 3;
 		return -2;
 	}
-	if (dell_simple_ci_smi(DELL_CLASS_ADMIN_PROP,
-			       DELL_SELECT_ADMIN_PROP,
-			       args, out))
-		return -2;
-	if (out[0] != 0 || (out[1] & DELL_ADMIN_MASK) == DELL_ADMIN_INSTALLED)
-		return -3;
-	return 2;
-#else
-	return -1;
-#endif
+	return admin_password_present();
 }
 
 /*
@@ -157,7 +312,6 @@ fwup_esrt_disabled(void)
 int
 fwup_enable_esrt(void)
 {
-#ifdef FWUPDATE_HAVE_LIBSMBIOS__
 	int rc;
 	rc = fwup_supported();
 	/* can't enable or already enabled */
@@ -166,28 +320,15 @@ fwup_enable_esrt(void)
 		return rc;
 	}
 	/* disabled in BIOS, but supported to be enabled via tool */
-	rc = token_is_bool(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
+	rc = query_token(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
 	if (!rc) {
 		efi_error(
 			"DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED is unsupported");
 		return -1;
 	}
-	rc = token_is_active(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
-	if (rc) {
-		efi_error("DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED is enabled");
-		return -2;
-	}
-	token_activate(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
-	rc = token_is_active(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
-	if (!rc) {
-		efi_error("DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED activation failed");
-		return -3;
-	}
+	activate_token(DELL_CAPSULE_FIRMWARE_UPDATES_ENABLED);
+
 	return 2;
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
 }
 
 /*


### PR DESCRIPTION
There is a kernel patch series that adds a character device
allowing performing SMBIOS calling direclty over ACPI-WMI.

Once this interface makes it into distros this means that
libsmbios could (eventually) be retired as software like
fwupdate can talk directly to the character device.

**NOTE: the kernel series is still under review right now.  This patch should not be merged until the name of the character device is finalized and patch series at least accepted into the maintainers tree.**
https://patchwork.kernel.org/patch/9972529/

It's just posted for allowing early review.