### PR TITLE
Fix capsule_image_size calculation in header (Fixes: #79)

### DIFF
--- a/efi/fwupdate.c
+++ b/efi/fwupdate.c
@@ -993,11 +993,6 @@ do_ux_csum(EFI_HANDLE loaded_image, UINT8 *buf, UINTN size)
 	current += capsule->HeaderSize;
 	left -= capsule->HeaderSize;
 
-	if (size < capsule->HeaderSize + capsule->CapsuleImageSize) {
-		dprint(L"Invalid capsule size %d\n", size);
-		return EFI_INVALID_PARAMETER;
-	}
-
 	payload_hdr = (ux_capsule_header_t *)(buf) + capsule->HeaderSize;
 	dprint(L"&PayloadHeader: 0x%08lx\n", payload_hdr);
 	dprint(L"PayloadHeader Size: %d\n", sizeof (*payload_hdr));


### PR DESCRIPTION
It should be the combination of:
 the capsule header
 the UX header
 the size of the image file
not some arbitrary 26 bytes header of the bmp.