### PR TITLE
Fix doc/Makefile dependency for install target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -38,12 +38,10 @@ install : | mandirs
 install : | $(foreach x, $(MAN1TARGETS), $(DESTDIR)$(mandir)/man1/$(x))
 install : | $(foreach x, $(MAN3TARGETS), $(DESTDIR)$(mandir)/man3/$(x))
 
-$(DESTDIR)$(mandir)/man1/%.1 : | mandirs
-$(DESTDIR)$(mandir)/man1/%.1 : %.1
+$(DESTDIR)$(mandir)/man1/%.1 : %.1 | mandirs
 	$(INSTALL) -m 644 $< $@
 
-$(DESTDIR)$(mandir)/man3/%.3 : | mandirs
-$(DESTDIR)$(mandir)/man3/%.3 : %.3
+$(DESTDIR)$(mandir)/man3/%.3 : %.3 | mandirs
 	$(INSTALL) -m 644 $< $@
 
 .PHONY: all clean test install mandirs


### PR DESCRIPTION
<pre>
This fixes GitHub issue #102
by making man document files require mandirs

For explicit rules, multiple rules for one target
results a merge of prerequisites [1]:

    example : preq-1
    example : | preq-3
    example : preq-2
        recipes

    <==> (equals)

    example : preq-1 preq-2 | preq-3
        recipes

For implicit rules, that is not:

    %.o : %.h
    %.o : %.c
        recipes

    <==>

    %.o : %.c
        recipes

    "%.o : %.h" w/o recipes means a Cancel Rule in implicit rule [2]
    which removes the specified implicit rule

[1]: https://www.gnu.org/software/make/manual/make.html#Multiple-Rules
[2]: https://www.gnu.org/software/make/manual/make.html#Canceling-Rules
</pre>