### PR TITLE
Add fwup_version()

### DIFF
--- a/linux/include/fwup.h
+++ b/linux/include/fwup.h
@@ -23,6 +23,7 @@
 extern int fwup_supported(void);
 extern int fwup_esrt_disabled(void);
 extern int fwup_enable_esrt(void);
+extern int fwup_version(void);
 
 #define FWUP_SUPPORTED_STATUS_UNSUPPORTED			0
 #define FWUP_SUPPORTED_STATUS_UNLOCKED				1

--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -2272,3 +2272,18 @@ fwup_get_debug_log(char **utf8, size_t *size)
 	*size = vsize >> 1;
 	return 0;
 }
+
+/**
+ * fwup_version
+ *
+ * Returns the installed runtime version of libfwupdate
+ *
+ * Returns: integer version
+ *
+ * Since: 12
+ */
+int
+fwup_version(void)
+{
+	return LIBFWUP_VERSION;
+}


### PR DESCRIPTION
This is required for fwupd, which needs to care about the runtime version
rather than the build-time version.