### PR TITLE
efi/fwupdate.c Correct a typographical error

### DIFF
--- a/efi/fwupdate.c
+++ b/efi/fwupdate.c
@@ -51,7 +51,7 @@ static int debugging;
 static VOID
 msleep(unsigned long msecs)
 {
-	gBS->Stall(msecs);
+	BS->Stall(msecs);
 }
 
 


### PR DESCRIPTION
```gcc -Og -g3 -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -fpic -Werror -Wall -Wextra -fshort-wchar -fno-merge-constants -ffreestanding -fno-stack-protector -fno-stack-check --std=gnu11 -DCONFIG_x86_64 -I/usr/include/efi/ -I/usr/include/efi/x86_64/ -iquote/build/include "-DDEBUGDIR=L\"/\"" -mno-mmx -mno-sse -mno-red-zone -nostdinc -maccumulate-outgoing-args -DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI -I/usr/lib/gcc/x86_64-linux-gnu/7/include -c -o fwupdate.o fwupdate.c
fwupdate.c: In function 'msleep':
fwupdate.c:54:2: error: 'gBS' undeclared (first use in this function); did you mean 'BS'?
  gBS->Stall(msecs);
  ^~~
  BS
fwupdate.c:54:2: note: each undeclared identifier is reported only once for each function it appears in
/build/efi/Makefile:113: recipe for target 'fwupdate.o' failed
```