### PR TITLE
libfwup: shouldn't create ux capsule when getting ux capsule info error

### DIFF
--- a/linux/libfwup.c
+++ b/linux/libfwup.c
@@ -697,7 +697,7 @@ fwup_resource_iter_create(fwup_resource_iter **iter)
 
 	new->add_ux_capsule = true;
 	env = getenv("LIBFWUP_ADD_UX_CAPSULE");
-	if (env && !strcmp(env, "0") && fwup_get_ux_capsule_info(&x, &y) >= 0)
+	if ((env && !strcmp(env, "0")) || fwup_get_ux_capsule_info(&x, &y) < 0)
 		new->add_ux_capsule = false;
 
 	*iter = new;


### PR DESCRIPTION
Signed-off-by: Ivan Hu <ivan.hu@canonical.com>